### PR TITLE
Upgrade ruby-dogstatsd, fix tags collection

### DIFF
--- a/lib/logstash/outputs/dogstatsd.rb
+++ b/lib/logstash/outputs/dogstatsd.rb
@@ -89,7 +89,7 @@ class LogStash::Outputs::Dogstatsd < LogStash::Outputs::Base
 
     metric_opts = {
       :sample_rate => @sample_rate,
-      :tags => @metric_tags.map { |t| event.sprintf(t) }
+      :tags => @metric_tags.collect { |t| event.sprintf(t) }
     }
 
     @increment.each do |metric|

--- a/lib/logstash/outputs/dogstatsd.rb
+++ b/lib/logstash/outputs/dogstatsd.rb
@@ -1,16 +1,13 @@
 # encoding: utf-8
 require "logstash/outputs/base"
 require "logstash/namespace"
-
+require "datadog/statsd"
 # This is a hack to load the dogstatsd-ruby gem's statsd.rb file into a
 # namespace so as to not clobber the top-level Statsd provided by the
 # much-more-popular Statsd gem. The problem is that both gems have a file named
 # 'statsd.rb' that you are supposed to load. Why did Datadog not name their file
 # differently? Who knows!
 # (see: https://github.com/DataDog/dogstatsd-ruby/pull/3)
-module Datadog
-  module_eval(File.read(Gem.find_files('**/statsd.rb').grep(/dogstatsd/).first))
-end
 
 # dogstatsd is a fork of the statsd protocol which aggregates statistics, such
 # as counters and timers, and ships them over UDP to the dogstatsd-server

--- a/logstash-output-dogstatsd.gemspec
+++ b/logstash-output-dogstatsd.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   # This version is pinned exactly to ensure that upgrades don't break the
   # gnarly `module_eval` hack in lib/logstash/outputs/dogstatsd.rb.
-  s.add_runtime_dependency 'dogstatsd-ruby', '= 1.6'
+  s.add_runtime_dependency "dogstatsd-ruby", ">= 2.0.0", "< 3.0.0"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'overcommit'


### PR DESCRIPTION
#1 - Upgraded ruby-dogstatsd which support tags escaping - avoiding the "hack"
#2 - Changed tags evaluation to "collect"