### PR TITLE
Update logstash-core dependency to 6 and apply minor dogstats version bump

### DIFF
--- a/logstash-output-dogstatsd.gemspec
+++ b/logstash-output-dogstatsd.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-dogstatsd'
-  s.version         = '5.0.0'
+  s.version         = '6.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send metrics to StatsD"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", "~> 5.0"
+  s.add_runtime_dependency "logstash-core", "~> 6.0"
   s.add_runtime_dependency 'logstash-input-generator'
 
-  s.add_runtime_dependency 'dogstatsd-ruby', '~> 3.0'
+  s.add_runtime_dependency 'dogstatsd-ruby', '~> 3.1'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'overcommit'


### PR DESCRIPTION
This change should enable plugin compatibility with version 6.x of
Logstash.